### PR TITLE
bump cortex-m version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itm_logger"
-version = "0.1.2"
+version = "0.1.3-pre.0"
 authors = ["cs2dsb <cs2dsb@gmail.com>"]
 edition = "2018"
 description = "An implementation of the log facade that sends logging information over ITM stim port 0"
@@ -13,8 +13,8 @@ documentation = "https://docs.rs/itm_logger"
 homepage = "https://github.com/cs2dsb/itm_logger.rs"
 
 [dependencies]
-cortex-m = { version = "0.6.2", optional = true }
-log = { version = "0.4.6", default-features = false, optional = true }
+cortex-m = { version = "0.7", optional = true }
+log = { version = "0.4", default-features = false, optional = true }
 
 [features]
 default = [ "logging" ] #Set up this way so it's possible to disable logging and have the log macros expand to noop

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itm_logger"
-version = "0.1.3-pre.0"
+version = "0.1.3-alpha.0"
 authors = ["cs2dsb <cs2dsb@gmail.com>"]
 edition = "2018"
 description = "An implementation of the log facade that sends logging information over ITM stim port 0"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -32,7 +32,7 @@ pub fn update_tpiu_baudrate(trace_clk_freq: u32, baud: u32) -> Result<(), Error>
     } else {
         let prescaler = (trace_clk_freq / baud) - 1;
         unsafe {
-            (*TPIU::ptr()).acpr.write(prescaler);
+            (*TPIU::PTR).acpr.write(prescaler);
         }
         Ok(())
     }
@@ -80,7 +80,7 @@ impl Log for ItmLogger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             unsafe {
-                let itm = &mut (*ITM::ptr());
+                let itm = &mut (*ITM::PTR);
                 interrupt::free(|_| {
                     iprintln!(
                         &mut itm.stim[STIM_PORT_NUMBER],


### PR DESCRIPTION
Hello,

Thanks for providing this crate. I saw that a new version of `cortex-m` is available now.
I bumped the version. Nothing broke, but I got a deprecation warning about using an associated const instead of a method which I fixed.

Doing this probably warrants a new minor version, so I created an alpha version.